### PR TITLE
ペア名を自動生成するドメインサービスを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
+
+# test
+coverage

--- a/src/domain/pair/__tests__/join-pair.test.ts
+++ b/src/domain/pair/__tests__/join-pair.test.ts
@@ -18,6 +18,7 @@ describe("JoinPair", () => {
     save: jest.fn(),
     getVacantPairList: jest.fn(),
     getAllPairList: jest.fn(),
+    getPairListInTeam: jest.fn(),
   }
   const teamRepositoryMock: jest.Mocked<ITeamRepository> = {
     save: jest.fn(),

--- a/src/domain/pair/__tests__/join-pair.test.ts
+++ b/src/domain/pair/__tests__/join-pair.test.ts
@@ -118,11 +118,11 @@ describe("JoinPair", () => {
         }),
       ])
       pairFactoryMock.create.mockImplementation(
-        (props: { name: string; participantIdList: ParticipantId[] }) =>
+        async ({ teamId, participantIdList }) =>
           Pair.reconstruct(PairId.reconstruct("b"), {
-            name: PairName.reconstruct(props.name),
-            participantIdList: props.participantIdList,
-            teamId: TeamId.reconstruct("1"),
+            name: PairName.reconstruct("b"),
+            participantIdList: participantIdList,
+            teamId,
           })
       )
       // team-repositoryは3名のペアが所属しているチームを返す

--- a/src/domain/pair/__tests__/pair-factory.test.ts
+++ b/src/domain/pair/__tests__/pair-factory.test.ts
@@ -1,0 +1,44 @@
+import { ParticipantId } from "../../participant/participant-id"
+import { TeamId } from "../../team/team-id"
+import { Pair } from "../pair"
+import { PairFactory } from "../pair-factory"
+import { PairId } from "../pair-id"
+import { PairName } from "../pair-name"
+import { PairNameFactory } from "../pair-name-factory"
+
+describe(`PairFactory`, () => {
+  const pairNameFactoryMock: jest.Mocked<PairNameFactory> = {
+    // @ts-expect-error _brand
+    _brand: undefined,
+    // @ts-expect-error private value
+    pairRepository: undefined,
+    create: jest.fn(),
+  }
+
+  let pairFactory: PairFactory
+  beforeEach(() => {
+    pairFactory = new PairFactory(pairNameFactoryMock)
+  })
+
+  it(`ペアを作成できる`, async () => {
+    pairNameFactoryMock.create.mockResolvedValue(PairName.reconstruct("a"))
+
+    const actual = await pairFactory.create({
+      teamId: TeamId.reconstruct("1"),
+      participantIdList: [
+        ParticipantId.reconstruct("participant-a"),
+        ParticipantId.reconstruct("participant-b"),
+      ],
+    })
+    const expected = Pair.reconstruct(expect.any(PairId), {
+      name: PairName.reconstruct("a"),
+      teamId: TeamId.reconstruct("1"),
+      participantIdList: [
+        ParticipantId.reconstruct("participant-a"),
+        ParticipantId.reconstruct("participant-b"),
+      ],
+    })
+
+    expect(actual).toStrictEqual(expected)
+  })
+})

--- a/src/domain/pair/__tests__/pair-name-factory.test.ts
+++ b/src/domain/pair/__tests__/pair-name-factory.test.ts
@@ -1,0 +1,28 @@
+import { PairNameFactory } from "../pair-name-factory"
+
+describe(`PairNameFactory`, () => {
+  let pairNameFactory: PairNameFactory
+  beforeEach(() => {
+    pairNameFactory = new PairNameFactory()
+  })
+
+  describe(`チーム内で重複のないペア名を生成する`, () => {
+    it(`チーム内にペアが一つもない場合、 "a" を生成`, async () => {
+      const name = await pairNameFactory.create()
+      expect(name.props.value).toBe("a")
+    })
+    describe(`チーム内にペアが存在する場合、重複の無い一番若いアルファベットで生成する`, () => {
+      it(`"a", "b" が存在する場合、 "c" を生成する`, async () => {
+        const name = await pairNameFactory.create()
+        expect(name.props.value).toBe("c")
+      })
+      it(`"a", "c" が存在する場合、 "b" を生成する`, async () => {
+        const name = await pairNameFactory.create()
+        expect(name.props.value).toBe("b")
+      })
+    })
+    it(`チーム内にペアが26以上存在する場合、エラーになる`, async () => {
+      await expect(pairNameFactory.create()).rejects.toThrowError()
+    })
+  })
+})

--- a/src/domain/pair/__tests__/pair-name-factory.test.ts
+++ b/src/domain/pair/__tests__/pair-name-factory.test.ts
@@ -1,28 +1,94 @@
 import { PairNameFactory } from "../pair-name-factory"
+import { IPairRepository } from "../interface/pair-repository"
+import { TeamId } from "../../team/team-id"
+import { Pair } from "../pair"
+import { PairId } from "../pair-id"
+import { PairName } from "../pair-name"
 
 describe(`PairNameFactory`, () => {
+  const pairRepositoryMock: jest.Mocked<IPairRepository> = {
+    getAllPairList: jest.fn(),
+    getPairListInTeam: jest.fn(),
+    getVacantPairList: jest.fn(),
+    save: jest.fn(),
+  }
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
   let pairNameFactory: PairNameFactory
   beforeEach(() => {
-    pairNameFactory = new PairNameFactory()
+    pairNameFactory = new PairNameFactory(pairRepositoryMock)
+  })
+
+  const team_id_1 = TeamId.reconstruct("1")
+
+  const pair_a = Pair.reconstruct(PairId.reconstruct("a"), {
+    name: PairName.reconstruct("a"),
+    teamId: team_id_1,
+    participantIdList: [],
+  })
+  const pair_b = Pair.reconstruct(PairId.reconstruct("b"), {
+    name: PairName.reconstruct("b"),
+    teamId: team_id_1,
+    participantIdList: [],
+  })
+  const pair_c = Pair.reconstruct(PairId.reconstruct("c"), {
+    name: PairName.reconstruct("c"),
+    teamId: team_id_1,
+    participantIdList: [],
   })
 
   describe(`チーム内で重複のないペア名を生成する`, () => {
     it(`チーム内にペアが一つもない場合、 "a" を生成`, async () => {
-      const name = await pairNameFactory.create()
+      pairRepositoryMock.getPairListInTeam.mockResolvedValue([])
+
+      const name = await pairNameFactory.create(team_id_1)
       expect(name.props.value).toBe("a")
     })
+
     describe(`チーム内にペアが存在する場合、重複の無い一番若いアルファベットで生成する`, () => {
       it(`"a", "b" が存在する場合、 "c" を生成する`, async () => {
-        const name = await pairNameFactory.create()
+        pairRepositoryMock.getPairListInTeam.mockResolvedValue([pair_a, pair_b])
+
+        const name = await pairNameFactory.create(team_id_1)
         expect(name.props.value).toBe("c")
       })
       it(`"a", "c" が存在する場合、 "b" を生成する`, async () => {
-        const name = await pairNameFactory.create()
+        pairRepositoryMock.getPairListInTeam.mockResolvedValue([pair_a, pair_c])
+
+        const name = await pairNameFactory.create(team_id_1)
         expect(name.props.value).toBe("b")
       })
+      it(`"a", "b", ..., "y" が存在する場合、 "z" を生成する`, async () => {
+        pairRepositoryMock.getPairListInTeam.mockResolvedValue(
+          Array.from("abcdefghijklmnopqrstuvwxy").map((name) =>
+            Pair.reconstruct(PairId.reconstruct(name), {
+              name: PairName.reconstruct(name),
+              teamId: team_id_1,
+              participantIdList: [],
+            })
+          )
+        )
+
+        const name = await pairNameFactory.create(team_id_1)
+        expect(name.props.value).toBe("z")
+      })
     })
+
     it(`チーム内にペアが26以上存在する場合、エラーになる`, async () => {
-      await expect(pairNameFactory.create()).rejects.toThrowError()
+      pairRepositoryMock.getPairListInTeam.mockResolvedValue(
+        Array.from("abcdefghijklmnopqrstuvwxyz").map((name) =>
+          Pair.reconstruct(PairId.reconstruct(name), {
+            name: PairName.reconstruct(name),
+            teamId: team_id_1,
+            participantIdList: [],
+          })
+        )
+      )
+      await expect(pairNameFactory.create(team_id_1)).rejects.toThrowError(
+        "これ以上ペアを作成できません"
+      )
     })
   })
 })

--- a/src/domain/pair/__tests__/pair-name.test.ts
+++ b/src/domain/pair/__tests__/pair-name.test.ts
@@ -3,21 +3,23 @@ import { PairName } from "../pair-name"
 describe("PairName", () => {
   describe("ペアの名前の長さは1文字", () => {
     it(`名前を "a" にすると正しく作成できる`, () => {
-      const pairName = PairName.create("a")
+      const pairName = PairName.createFromFactory("a")
       expect(pairName).toEqual(expect.any(PairName))
     })
     it("名前を空にするとエラーになる", () => {
-      expect(() => PairName.create("")).toThrowError(
+      expect(() => PairName.createFromFactory("")).toThrowError(
         "pair-name cannot be empty"
       )
     })
     it(`名前が2文字以上の場合エラーになる`, () => {
-      expect(() => PairName.create("aa")).toThrowError("pair-name is too long")
+      expect(() => PairName.createFromFactory("aa")).toThrowError(
+        "pair-name is too long"
+      )
     })
   })
   describe("ペアの名前は英小文字のみ", () => {
     it(`名前に大文字が含まれている場合エラーになる`, () => {
-      expect(() => PairName.create("A")).toThrowError(
+      expect(() => PairName.createFromFactory("A")).toThrowError(
         "pair-name cannot be uppercase"
       )
     })

--- a/src/domain/pair/interface/pair-repository.ts
+++ b/src/domain/pair/interface/pair-repository.ts
@@ -1,7 +1,9 @@
 import { Pair } from "../pair"
+import { TeamId } from "../../team/team-id"
 
 export interface IPairRepository {
   save(pair: Pair): Promise<void>
   getAllPairList(): Promise<Pair[]>
+  getPairListInTeam(teamId: TeamId): Promise<Pair[]>
   getVacantPairList(): Promise<Pair[]>
 }

--- a/src/domain/pair/join-pair.ts
+++ b/src/domain/pair/join-pair.ts
@@ -48,10 +48,11 @@ export class JoinPair extends DomainService<"join-pair"> {
       const targetPair = pairs[0]
       // ターゲットのペアから1人脱退
       const { removedParticipantId } = targetPair.removeParticipant()
-      // もう一つペアを作成
+      // もう一つペアを作成 (同じチームにする)
       // TODO: 名前はチーム内でかぶらないようにしたいので、factoryを修正する
       const newPair = this.pairFactory.create({
         name: "b",
+        teamId: targetPair.teamId,
         participantIdList: [removedParticipantId, participant.id],
       })
       // チームに加入する

--- a/src/domain/pair/join-pair.ts
+++ b/src/domain/pair/join-pair.ts
@@ -49,9 +49,7 @@ export class JoinPair extends DomainService<"join-pair"> {
       // ターゲットのペアから1人脱退
       const { removedParticipantId } = targetPair.removeParticipant()
       // もう一つペアを作成 (同じチームにする)
-      // TODO: 名前はチーム内でかぶらないようにしたいので、factoryを修正する
-      const newPair = this.pairFactory.create({
-        name: "b",
+      const newPair = await this.pairFactory.create({
         teamId: targetPair.teamId,
         participantIdList: [removedParticipantId, participant.id],
       })

--- a/src/domain/pair/pair-factory.ts
+++ b/src/domain/pair/pair-factory.ts
@@ -1,18 +1,24 @@
 import { DomainService } from "../shared/domainService"
 import { Pair } from "./pair"
-import { PairName } from "./pair-name"
 import { ParticipantId } from "../participant/participant-id"
 import { TeamId } from "../team/team-id"
+import { PairNameFactory } from "./pair-name-factory"
 
 export interface PairFactoryProps {
-  name: string
   teamId: TeamId
   participantIdList: ParticipantId[]
 }
 
 export class PairFactory extends DomainService<"pair-factory"> {
-  public create({ name, teamId, participantIdList }: PairFactoryProps): Pair {
-    const pairName = PairName.create(name)
+  constructor(private pairNameFactory: PairNameFactory) {
+    super()
+  }
+
+  public async create({
+    teamId,
+    participantIdList,
+  }: PairFactoryProps): Promise<Pair> {
+    const pairName = await this.pairNameFactory.create()
     return Pair.createFromFactory({
       name: pairName,
       teamId,

--- a/src/domain/pair/pair-factory.ts
+++ b/src/domain/pair/pair-factory.ts
@@ -2,17 +2,20 @@ import { DomainService } from "../shared/domainService"
 import { Pair } from "./pair"
 import { PairName } from "./pair-name"
 import { ParticipantId } from "../participant/participant-id"
+import { TeamId } from "../team/team-id"
 
 export interface PairFactoryProps {
   name: string
+  teamId: TeamId
   participantIdList: ParticipantId[]
 }
 
 export class PairFactory extends DomainService<"pair-factory"> {
-  public create({ name, participantIdList }: PairFactoryProps): Pair {
+  public create({ name, teamId, participantIdList }: PairFactoryProps): Pair {
     const pairName = PairName.create(name)
     return Pair.createFromFactory({
       name: pairName,
+      teamId,
       participantIdList,
     })
   }

--- a/src/domain/pair/pair-factory.ts
+++ b/src/domain/pair/pair-factory.ts
@@ -18,7 +18,7 @@ export class PairFactory extends DomainService<"pair-factory"> {
     teamId,
     participantIdList,
   }: PairFactoryProps): Promise<Pair> {
-    const pairName = await this.pairNameFactory.create()
+    const pairName = await this.pairNameFactory.create(teamId)
     return Pair.createFromFactory({
       name: pairName,
       teamId,

--- a/src/domain/pair/pair-name-factory.ts
+++ b/src/domain/pair/pair-name-factory.ts
@@ -1,15 +1,42 @@
 import { DomainService } from "../shared/domainService"
 import { PairName } from "./pair-name"
+import { IPairRepository } from "../pair/interface/pair-repository"
+import { TeamId } from "../team/team-id"
 
 export class PairNameFactory extends DomainService<"pair-name-factory"> {
-  constructor() {
+  constructor(private pairRepository: IPairRepository) {
     super()
   }
   /**
    * ペア名を自動生成
    */
-  async create(): Promise<PairName> {
-    // TODO:
-    return PairName.createFromFactory("")
+  async create(teamId: TeamId): Promise<PairName> {
+    const pairs = await this.pairRepository.getPairListInTeam(teamId)
+
+    if (pairs.length >= 26) {
+      throw new Error("これ以上ペアを作成できません")
+    }
+
+    if (pairs.length === 0) {
+      return PairName.createFromFactory("a")
+    }
+
+    const ALPHABET_USED: Record<string, boolean> = Object.fromEntries(
+      Array.from("abcdefghijklmnopqrstuvwxyz").map((alphabet) => [
+        alphabet,
+        false,
+      ])
+    )
+    pairs.forEach((pair) => {
+      ALPHABET_USED[pair.name.props.value] = true
+    })
+    const unusedAlphabet = Object.entries(ALPHABET_USED).find(
+      ([, used]) => !used
+    )
+    if (!unusedAlphabet) {
+      throw new Error("予期しないエラー")
+    }
+    const [name] = unusedAlphabet
+    return PairName.createFromFactory(name)
   }
 }

--- a/src/domain/pair/pair-name-factory.ts
+++ b/src/domain/pair/pair-name-factory.ts
@@ -1,0 +1,15 @@
+import { DomainService } from "../shared/domainService"
+import { PairName } from "./pair-name"
+
+export class PairNameFactory extends DomainService<"pair-name-factory"> {
+  constructor() {
+    super()
+  }
+  /**
+   * ペア名を自動生成
+   */
+  async create(): Promise<PairName> {
+    // TODO:
+    return PairName.createFromFactory("")
+  }
+}

--- a/src/domain/pair/pair-name.ts
+++ b/src/domain/pair/pair-name.ts
@@ -8,7 +8,7 @@ export class PairName extends ValueObject<PairNameProps, "pair-name"> {
   private constructor(props: PairNameProps) {
     super(props)
   }
-  public static create(name: string): PairName {
+  public static createFromFactory(name: string): PairName {
     if (name === "") {
       throw new Error("pair-name cannot be empty")
     }

--- a/src/domain/pair/pair.ts
+++ b/src/domain/pair/pair.ts
@@ -26,6 +26,9 @@ export class Pair extends Entity<PairProps, "pair", PairId> {
     return new Pair(id, props)
   }
 
+  public get name(): PairName {
+    return this.props.name
+  }
   public get teamId(): TeamId {
     return this.props.teamId
   }


### PR DESCRIPTION
- ペア名を自動生成するドメインサービスを追加
  - コード: [`src/domain/pair/pair-name-factory.ts`](https://github.com/sushidesu/prahachallenge-ddd/blob/db05ac870dafa0ab69cbb36092de664907aea7d7/src/domain/pair/pair-name-factory.ts)
  - テスト: [`src/domain/pair/__tests__/pair-name-factory.test.ts`](https://github.com/sushidesu/prahachallenge-ddd/blob/db05ac870dafa0ab69cbb36092de664907aea7d7/src/domain/pair/__tests__/pair-name-factory.test.ts)
  - チーム内で被らないような名前を生成
  - 空きのあるアルファベットを順番に使用