### PR TITLE
Refactor: PairRepository.getVacantPairList()をドメインサービスに移動

### DIFF
--- a/src/config/participant-router.ts
+++ b/src/config/participant-router.ts
@@ -10,6 +10,7 @@ import { ParticipantFactory } from "../domain/participant/participant-factory"
 import { PairNameFactory } from "../domain/pair/pair-name-factory"
 import { PairFactory } from "../domain/pair/pair-factory"
 import { JoinPair } from "../domain/pair/join-pair"
+import { GetVacantPairList } from "../domain/pair/get-vacant-pair-list"
 
 const participantRouter = Router()
 
@@ -26,7 +27,13 @@ const checkEmailAlreadyExists = new CheckEmailAlreadyExists(
 const participantFactory = new ParticipantFactory(checkEmailAlreadyExists)
 const pairNameFactory = new PairNameFactory(pairRepository)
 const pairFactory = new PairFactory(pairNameFactory)
-const joinPair = new JoinPair(pairRepository, teamRepository, pairFactory)
+const getVacantPairList = new GetVacantPairList(pairRepository)
+const joinPair = new JoinPair(
+  pairRepository,
+  teamRepository,
+  pairFactory,
+  getVacantPairList
+)
 
 // usecase
 const joinPrahaChallengeUsecase = new JoinPrahaChallengeUsecase(

--- a/src/domain/pair/__tests__/get-vacant-pair-list.test.ts
+++ b/src/domain/pair/__tests__/get-vacant-pair-list.test.ts
@@ -1,0 +1,63 @@
+import { mock } from "jest-mock-extended"
+import { GetVacantPairList } from "../get-vacant-pair-list"
+import { IPairRepository } from "../interface/pair-repository"
+import { Pair } from "../pair"
+import { PairId } from "../pair-id"
+import { PairName } from "../pair-name"
+import { ParticipantId } from "../../participant/participant-id"
+import { TeamId } from "../../team/team-id"
+
+describe(`GetVacantPairList`, () => {
+  const pairRepositoryMock = mock<IPairRepository>()
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  let getVacantPairList: GetVacantPairList
+  beforeEach(() => {
+    getVacantPairList = new GetVacantPairList(pairRepositoryMock)
+  })
+
+  const pairA_vacant = Pair.reconstruct(PairId.reconstruct("a"), {
+    name: PairName.reconstruct("a"),
+    teamId: TeamId.reconstruct("1"),
+    participantIdList: [
+      ParticipantId.reconstruct("01"),
+      ParticipantId.reconstruct("02"),
+    ],
+  })
+  const pairB_full = Pair.reconstruct(PairId.reconstruct("b"), {
+    name: PairName.reconstruct("b"),
+    teamId: TeamId.reconstruct("1"),
+    participantIdList: [
+      ParticipantId.reconstruct("03"),
+      ParticipantId.reconstruct("04"),
+      ParticipantId.reconstruct("05"),
+    ],
+  })
+  const pairC_vacant = Pair.reconstruct(PairId.reconstruct("c"), {
+    name: PairName.reconstruct("c"),
+    teamId: TeamId.reconstruct("1"),
+    participantIdList: [
+      ParticipantId.reconstruct("06"),
+      ParticipantId.reconstruct("07"),
+    ],
+  })
+
+  it(`空きのあるペアを返す`, async () => {
+    pairRepositoryMock.getAllPairList.mockResolvedValue([
+      pairA_vacant,
+      pairB_full,
+      pairC_vacant,
+    ])
+    const actual = await getVacantPairList.do()
+    const expected = [pairA_vacant, pairC_vacant]
+    expect(actual).toStrictEqual(expected)
+  })
+
+  it(`空きのあるペアがない場合、空のリストを返す`, async () => {
+    pairRepositoryMock.getAllPairList.mockResolvedValue([pairB_full])
+    const actual = await getVacantPairList.do()
+    expect(actual).toEqual([])
+  })
+})

--- a/src/domain/pair/__tests__/join-pair.test.ts
+++ b/src/domain/pair/__tests__/join-pair.test.ts
@@ -1,23 +1,28 @@
 import { mock } from "jest-mock-extended"
 import { JoinPair } from "../join-pair"
-import { IPairRepository } from "../interface/pair-repository"
-import { Pair } from "../pair"
-import { PairId } from "../pair-id"
-import { ParticipantId } from "../../participant/participant-id"
-import { PairName } from "../pair-name"
-import { Participant } from "../../participant/participant"
-import { ParticipantName } from "../../participant/participant-name"
-import { Email } from "../../participant/email"
-import { PairFactory } from "../pair-factory"
+// entity
 import { TeamId } from "../../team/team-id"
-import { ITeamRepository } from "../../team/interface/team-repository"
 import { Team } from "../../team/team"
 import { TeamName } from "../../team/team-name"
+import { Pair } from "../pair"
+import { PairId } from "../pair-id"
+import { PairName } from "../pair-name"
+import { Participant } from "../../participant/participant"
+import { ParticipantId } from "../../participant/participant-id"
+import { ParticipantName } from "../../participant/participant-name"
+import { Email } from "../../participant/email"
+// repository
+import { ITeamRepository } from "../../team/interface/team-repository"
+import { IPairRepository } from "../interface/pair-repository"
+// domain service
+import { PairFactory } from "../pair-factory"
+import { GetVacantPairList } from "../get-vacant-pair-list"
 
 describe("JoinPair", () => {
   const pairRepositoryMock = mock<IPairRepository>()
   const teamRepositoryMock = mock<ITeamRepository>()
   const pairFactoryMock = mock<PairFactory>()
+  const getVacantPairListMock = mock<GetVacantPairList>()
   afterEach(() => {
     jest.resetAllMocks()
   })
@@ -39,7 +44,8 @@ describe("JoinPair", () => {
     joinPair = new JoinPair(
       pairRepositoryMock,
       teamRepositoryMock,
-      pairFactoryMock
+      pairFactoryMock,
+      getVacantPairListMock
     )
   })
 
@@ -55,8 +61,8 @@ describe("JoinPair", () => {
         participantIdList: [participant_c, participant_d],
         teamId: TeamId.reconstruct("1"),
       })
-      // pair-repositoryは2名のペア * 2 を返す
-      pairRepositoryMock.getVacantPairList.mockResolvedValue([pairA, pairB])
+      // get-vacant-pair-listは2名のペア2つを返す
+      getVacantPairListMock.do.mockResolvedValue([pairA, pairB])
       // team-repositoryは2名のペア*2が所属しているチームを返す
       teamRepositoryMock.getTeamById.mockResolvedValue(
         Team.reconstruct(TeamId.reconstruct("1"), {
@@ -98,7 +104,7 @@ describe("JoinPair", () => {
   describe("全てのペアに空きがない場合、ペアを分割する", () => {
     it("3名のペアが1つ存在するとき、ペアを2つに分割し、加入する", async () => {
       // 空きのあるペアなし
-      pairRepositoryMock.getVacantPairList.mockResolvedValue([])
+      getVacantPairListMock.do.mockResolvedValue([])
       // pair-repositoryは3名のペアを1つ返す
       pairRepositoryMock.getAllPairList.mockResolvedValue([
         Pair.reconstruct(PairId.reconstruct("a"), {
@@ -154,7 +160,7 @@ describe("JoinPair", () => {
     })
   })
   it("ペアが1つも存在しない場合、エラーになる", async () => {
-    pairRepositoryMock.getVacantPairList.mockResolvedValue([])
+    getVacantPairListMock.do.mockResolvedValue([])
     pairRepositoryMock.getAllPairList.mockResolvedValue([])
     await expect(joinPair.do(participant)).rejects.toThrowError(
       "no pair exists"

--- a/src/domain/pair/get-vacant-pair-list.ts
+++ b/src/domain/pair/get-vacant-pair-list.ts
@@ -1,0 +1,14 @@
+import { DomainService } from "../shared/domainService"
+import { Pair } from "./pair"
+import { IPairRepository } from "./interface/pair-repository"
+
+export class GetVacantPairList extends DomainService<"get-vacant-pair-list"> {
+  constructor(private readonly pairRepository: IPairRepository) {
+    super()
+  }
+
+  async do(): Promise<readonly Pair[]> {
+    const allPairs = await this.pairRepository.getAllPairList()
+    return allPairs.filter((pair) => pair.canAcceptParticipant())
+  }
+}

--- a/src/domain/pair/interface/pair-repository.ts
+++ b/src/domain/pair/interface/pair-repository.ts
@@ -6,5 +6,4 @@ export interface IPairRepository {
   update(pair: Pair): Promise<void>
   getAllPairList(): Promise<Pair[]>
   getPairListInTeam(teamId: TeamId): Promise<Pair[]>
-  getVacantPairList(): Promise<Pair[]>
 }

--- a/src/domain/pair/join-pair.ts
+++ b/src/domain/pair/join-pair.ts
@@ -2,6 +2,7 @@ import { DomainService } from "../shared/domainService"
 import { Participant } from "../participant/participant"
 import { Pair } from "./pair"
 import { PairFactory } from "./pair-factory"
+import { GetVacantPairList } from "./get-vacant-pair-list"
 import { IPairRepository } from "./interface/pair-repository"
 import { Team } from "../team/team"
 import { ITeamRepository } from "../team/interface/team-repository"
@@ -10,7 +11,8 @@ export class JoinPair extends DomainService<"join-pair"> {
   constructor(
     private pairRepository: IPairRepository,
     private teamRepository: ITeamRepository,
-    private pairFactory: PairFactory
+    private pairFactory: PairFactory,
+    private getVacantPairList: GetVacantPairList
   ) {
     super()
   }
@@ -21,7 +23,7 @@ export class JoinPair extends DomainService<"join-pair"> {
     changedTeamList: Team[]
   }> {
     // 空きのあるペアを探す
-    const vacantPairs = await this.pairRepository.getVacantPairList()
+    const vacantPairs = await this.getVacantPairList.do()
 
     // 空きがある場合、そのペアに加入する
     // そのペアが所属しているチームにも加入する

--- a/src/infra/pair/pair-repository.ts
+++ b/src/infra/pair/pair-repository.ts
@@ -107,30 +107,11 @@ export class PairRepository implements IPairRepository {
     return pairs.map((pair) => this.build(pair))
   }
 
-  /**
-   * 空きのあるペアのリストを返す
-   */
-  async getVacantPairList(): Promise<Pair[]> {
-    // HELP: クエリではじめから弾くほうがパフォーマンス的には良いか？
-    // そもそもこのメソッドの存在自体が好ましくない？(ドメイン知識が漏れ出している？)
-    const pairs = await this.context.prisma.pair.findMany({
-      include: {
-        users: {
-          select: {
-            id: true,
-          },
-        },
-        teams: {
-          select: {
-            id: true,
-          },
-        },
-      },
-    })
-    return pairs
-      .map((pair) => this.build(pair))
-      .filter((pair) => pair.canAcceptParticipant())
-  }
+  //  async getVacantPairList(): Promise<Pair[]> {}
+  //
+  // HELP: クエリではじめから弾くほうがパフォーマンス的には良いか？
+  // そもそもこのメソッドの存在自体が好ましくない？(ドメイン知識が漏れ出している？)
+  // -> get-vacant-pair-list ドメインサービスに移行しました
 
   private build(resource: PrismaPairWithRelations): Pair {
     return Pair.reconstruct(PairId.reconstruct(resource.id), {

--- a/src/infra/pair/tests/pair-repository-read.integration.test.ts
+++ b/src/infra/pair/tests/pair-repository-read.integration.test.ts
@@ -94,23 +94,8 @@ describe(`PairRepository (read)`, () => {
       expect(actual).toStrictEqual(expected)
     })
   })
-
-  describe(`getVacantPairList()`, () => {
-    it(`空きのあるペアのリストを返す`, async () => {
-      const actual = await pairRepository.getVacantPairList()
-      const expected = [
-        Pair.reconstruct(PairId.reconstruct("id-pair-b"), {
-          name: PairName.reconstruct("b"),
-          teamId: TeamId.reconstruct("id-team-2"),
-          participantIdList: [
-            ParticipantId.reconstruct("id-user-04"),
-            ParticipantId.reconstruct("id-user-05"),
-          ],
-        }),
-      ]
-      // HELP: いろいろなプロパティがあってテスト結果が見づらいのでlength飲みを確認するテストを追加したが、もっと良い方法はあるか？
-      expect(actual.length).toBe(1)
-      expect(actual).toStrictEqual(expected)
-    })
-  })
 })
+
+// HELP: いろいろなプロパティがあってテスト結果が見づらいのでlength飲みを確認するテストを追加したが、もっと良い方法はあるか？
+// expect(actual.length).toBe(1)
+// expect(actual).toStrictEqual(expected)


### PR DESCRIPTION
- リポジトリをシンプルに保つために移動した